### PR TITLE
Couple of `ref()` fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,9 @@ module.exports = postcss.plugin('postcss-ref', function (opts) {
                         })
                     }
                 } else if (type === 'rule') {
-                    ruleCache[node.selector] = node
+                    if (node.parent.type !== 'atrule') {
+                      ruleCache[node.selector] = node
+                    }
                 } else if (type === 'decl') {
                     if (node.value.indexOf('ref(') !== -1) {
                         refCache.push(node)
@@ -85,7 +87,7 @@ module.exports = postcss.plugin('postcss-ref', function (opts) {
                     }
                 })
 
-                decl.value = newValue
+                decl.value = decl.value.replace(match[0], newValue)
             })
         }
     }


### PR DESCRIPTION
- Fix media rules overwriting base rules
- Substring replace the value instead of full overriding so we can do `-ref()`
